### PR TITLE
Formatting and Small Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://github.com/anish-lakkapragada/SeaLion/blob/main/logo.png?raw=true" width = 300 height = 300 >
+    <img src="https://github.com/anish-lakkapragada/SeaLion/blob/main/logo.png?raw=true" width=300 height=300 >
 </p>
 
 # SeaLion
@@ -22,7 +22,7 @@ of the way.
 
 <p align="center">
     <img src="https://raw.githubusercontent.com/anish-lakkapragada/SeaLion/main/sealion_demo.gif" width = 580 height = 326>
-    <br />
+    <br>
     <i>SeaLion in Action</i>
 </p>
 
@@ -268,7 +268,7 @@ Plenty of articles and people helped me a long way. Some of the tougher
 questions I dealt with were Automatic Differentiation in neural
 networks, in which this
 [tutorial](https://www.youtube.com/watch?v=o64FV-ez6Gw) helped me. I
-also got some help on the O(n\^2) time complexity problem of the
+also got some help on the `O(n^2)` time complexity problem of the
 denominator of t-SNE from this
 [article](https://nlml.github.io/in-raw-numpy/in-raw-numpy-t-sne/) and
 understood the mathematical derivation for the gradients (original paper

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
     read_me_description = fh.read()
 
 with open("requirements.txt") as reqs:
-    requirements = reqs.read().split("\n")
+    requirements = reqs.read().strip().split("\n")
 
 non_python_files = [
     "cython_decision_tree_functions.pyx",


### PR DESCRIPTION
1. Strip before splitting in `SeaLion/setup.py`. Used to leave a blank entry at the end of requirements list: `["module1", "module2", ""]`
2. Markdown formatting in `SeaLion/README.md`, such as removing extra spaces.